### PR TITLE
innsendingsiden skal være tilpasset mobilvisning. Sidescrolling på gr…

### DIFF
--- a/src/frontend/felles/Knapp.tsx
+++ b/src/frontend/felles/Knapp.tsx
@@ -4,5 +4,6 @@ import { Button } from '@navikt/ds-react';
 const KnappMedPadding = styled(Button)`
   padding-left: var(--navds-spacing-10);
   padding-right: var(--navds-spacing-10);
+  height: 3rem;
 `;
 export default KnappMedPadding;

--- a/src/frontend/komponenter/EkstraDokumentasjonsbehovBoks.tsx
+++ b/src/frontend/komponenter/EkstraDokumentasjonsbehovBoks.tsx
@@ -14,9 +14,8 @@ import { IDokumentasjonsbehov } from '../typer/ettersending';
 import Panel from 'nav-frontend-paneler';
 import AlertStripe, { alertMelding } from './AlertStripe';
 import { filstørrelse_10MB } from '../utils/filer';
-import KnappMedPadding from '../nav-komponenter/Knapp';
-import { Alert, Button } from '@navikt/ds-react';
-import { Delete } from '@navikt/ds-icons';
+import KnappMedPadding from '../felles/Knapp';
+import { Alert } from '@navikt/ds-react';
 
 const StyledSelect = styled(Select)`
   margin-top: 1rem;
@@ -27,29 +26,14 @@ const StyledPanel = styled(Panel)`
   margin-bottom: 1rem;
 `;
 
-const SekundærKnapp = styled(KnappMedPadding)`
-  margin-bottom: 0rem;
-`;
-
-const DivMidtstillInnhold = styled.div`
-  margin-top: 1rem;
+const FlexBox = styled.div`
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
 `;
-const Grid = styled.div`
-  display: grid;
-  grid-template-columns: 34.5rem 3rem;
-  align-items: baseline;
-`;
 
-const FlexRow = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: -2.5rem;
-`;
-
-const DeleteButton = styled(Button)`
-  z-index: 999;
+const KnappMedMargin = styled(KnappMedPadding)`
+  margin: 1rem 0.5rem 0rem 0.5rem;
 `;
 
 const StyledAlertStripe = styled(AlertStripe)`
@@ -117,23 +101,10 @@ export const EkstraDokumentasjonsbehovBoks: React.FC<IProps> = ({
     settAlertStripeMelding(alertMelding.MANGLER_BEGGE_TYPER);
   };
 
-  const slettInnsending = () => {
-    slettEkstraInnsending(innsending.id);
-  };
-
   return (
     <StyledPanel border>
       {!harLåstValg && (
         <>
-          <FlexRow>
-            <DeleteButton
-              type={'button'}
-              variant={'tertiary'}
-              icon={<Delete title={'Søppeldunk'} />}
-              onClick={slettInnsending}
-              title={'Slett opplastede vedlegg'}
-            />
-          </FlexRow>
           <StyledSelect
             label="Hvilken stønadstype gjelder innsendingen for?"
             onChange={(event: ChangeEvent<HTMLSelectElement>) => {
@@ -168,27 +139,16 @@ export const EkstraDokumentasjonsbehovBoks: React.FC<IProps> = ({
       )}
       {harLåstValg && (
         <>
-          <Grid>
-            <Alert
-              variant={erDokumentasjonSendt ? 'success' : 'warning'}
-              inline
-            >
-              <strong>{innsending.beskrivelse}</strong>
-            </Alert>
-            <DeleteButton
-              type={'button'}
-              variant={'tertiary'}
-              icon={<Delete title={'Søppeldunk'} />}
-              onClick={slettInnsending}
-              title={'Slett opplastede vedlegg'}
-            />
-          </Grid>
+          <Alert variant={erDokumentasjonSendt ? 'success' : 'warning'} inline>
+            <strong>{innsending.beskrivelse}</strong>
+          </Alert>
           <p>
             <strong>Stønadstype: </strong>
             {stønadTypeTilTekst[valgtStønadType as StønadType]}
           </p>
           <Vedleggsopplaster
             innsending={innsending}
+            slettInnsedning={slettEkstraInnsending}
             oppdaterInnsending={oppdaterInnsending}
             maxFilstørrelse={filstørrelse_10MB}
             stønadType={valgtStønadType}
@@ -200,11 +160,19 @@ export const EkstraDokumentasjonsbehovBoks: React.FC<IProps> = ({
         </>
       )}
       {!harLåstValg && (
-        <DivMidtstillInnhold>
-          <SekundærKnapp variant={'secondary'} onClick={håndterKnappeKlikk}>
+        <FlexBox>
+          <KnappMedMargin
+            type={'button'}
+            variant={'tertiary'}
+            onClick={() => slettEkstraInnsending(innsending.id)}
+            title={'Slett opplastede vedlegg'}
+          >
+            Avbryt
+          </KnappMedMargin>
+          <KnappMedMargin variant={'secondary'} onClick={håndterKnappeKlikk}>
             Neste
-          </SekundærKnapp>
-        </DivMidtstillInnhold>
+          </KnappMedMargin>
+        </FlexBox>
       )}
       <StyledAlertStripe melding={alertStripeMelding} />
       {innsendingerUtenVedlegg.includes(innsending.id) && (

--- a/src/frontend/komponenter/Ettersendingsoversikt.tsx
+++ b/src/frontend/komponenter/Ettersendingsoversikt.tsx
@@ -28,7 +28,7 @@ import Stegindikator from 'nav-frontend-stegindikator';
 import { slåSammenSøknadOgEttersendinger } from '../utils/søknadshåndtering';
 import { logDokumentasjonsbehov, logSidevisning } from '../utils/amplitude';
 import { EOppsummeringstitler } from '../utils/oppsummeringssteg';
-import KnappMedPadding from '../nav-komponenter/Knapp';
+import KnappMedPadding from '../felles/Knapp';
 
 const SekundærKnapp = styled(KnappMedPadding)`
   margin: 1rem;

--- a/src/frontend/komponenter/InnsendingSide.tsx
+++ b/src/frontend/komponenter/InnsendingSide.tsx
@@ -3,7 +3,7 @@ import { DokumentasjonsbehovListe } from './DokumentasjonsbehovListe';
 import { EkstraDokumentasjonsbehovBoks } from './EkstraDokumentasjonsbehovBoks';
 import { IDokumentasjonsbehov, IEttersending } from '../typer/ettersending';
 import styled from 'styled-components';
-import KnappMedPadding from '../nav-komponenter/Knapp';
+import KnappMedPadding from '../felles/Knapp';
 import { alertMelding } from './AlertStripe';
 import { AddCircle } from '@navikt/ds-icons';
 import { Button } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Vedleggsopplaster.tsx
+++ b/src/frontend/komponenter/Vedleggsopplaster.tsx
@@ -9,19 +9,16 @@ import VedleggsopplasterModal from './VedleggsopplasterModal';
 import styled from 'styled-components';
 import { StønadType } from '../typer/stønad';
 import AlertStripe, { alertMelding } from './AlertStripe';
-import KnappMedPadding from '../nav-komponenter/Knapp';
+import KnappMedPadding from '../felles/Knapp';
 
-const Filopplaster = styled.div<{ visSkillelinje: boolean }>`
-    text-align: center;
-    border-bottom: ${(props) =>
-      props.visSkillelinje ? '2px dashed #59514b' : ''};
-    height: 64px;
-  }
+const FlexBox = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 `;
 
 const FilopplasterWrapper = styled.div`
-  max-width: 775px;
-  min-height: 68px;
+  max-width: 48rem;
 `;
 
 const AlertStripeMedPadding = styled(AlertStripe)`
@@ -29,9 +26,14 @@ const AlertStripeMedPadding = styled(AlertStripe)`
   margin-bottom: 2rem;
 `;
 
+const KnappMedMargin = styled(KnappMedPadding)`
+  margin: 0.25rem 0.5rem;
+`;
+
 interface IProps {
   oppdaterInnsending: (innsending: IDokumentasjonsbehov) => void;
   innsending: IDokumentasjonsbehov;
+  slettInnsedning?: (id: string) => void;
   maxFilstørrelse?: number;
   stønadType?: StønadType;
   beskrivelse: string;
@@ -40,6 +42,7 @@ interface IProps {
 
 const Vedleggsopplaster: React.FC<IProps> = ({
   innsending,
+  slettInnsedning,
   oppdaterInnsending,
   maxFilstørrelse,
   stønadType,
@@ -80,8 +83,18 @@ const Vedleggsopplaster: React.FC<IProps> = ({
       </Modal>
       <FilopplasterWrapper>
         {innsending.vedlegg.length === 0 && (
-          <Filopplaster visSkillelinje={innsending.vedlegg.length > 0}>
-            <KnappMedPadding
+          <FlexBox>
+            {slettInnsedning && (
+              <KnappMedMargin
+                type={'button'}
+                variant={'tertiary'}
+                onClick={() => slettInnsedning(innsending.id)}
+                title={'Slett opplastede vedlegg'}
+              >
+                Avbryt
+              </KnappMedMargin>
+            )}
+            <KnappMedMargin
               variant={'secondary'}
               onClick={() => {
                 settÅpenModal(true);
@@ -89,8 +102,8 @@ const Vedleggsopplaster: React.FC<IProps> = ({
               }}
             >
               Last opp fil(er)
-            </KnappMedPadding>
-          </Filopplaster>
+            </KnappMedMargin>
+          </FlexBox>
         )}
         {innsending.vedlegg.length >= 1 && !innsending.erSammenslått && (
           <AlertStripeMedPadding

--- a/src/frontend/komponenter/VedleggsopplasterModal.tsx
+++ b/src/frontend/komponenter/VedleggsopplasterModal.tsx
@@ -21,7 +21,7 @@ import heic2any from 'heic2any';
 import { DokumentType, StønadType, stønadTypeTilTekst } from '../typer/stønad';
 import Panel from 'nav-frontend-paneler';
 import axios from 'axios';
-import KnappMedPadding from '../nav-komponenter/Knapp';
+import KnappMedPadding from '../felles/Knapp';
 import { Upload } from '@navikt/ds-icons';
 import { BodyShort } from '@navikt/ds-react';
 


### PR DESCRIPTION
…unn avc for brede elementer skal ikke forekomme.

Under UU-testing fant jeg ut at ikke alle komponentene i ettersendingsløsningen er tilpasset mobilvisning. Har utbedret innsendingsiden i denne PRen og kommer til å fortsette på andre komponenter i etterfølgende PRer.

FØR:
<img width="371" alt="Skjermbilde 2022-11-20 kl  22 10 09" src="https://user-images.githubusercontent.com/32769446/203014739-1035413e-8a45-41c0-bdcc-bfd06701f800.png">

<img width="344" alt="Skjermbilde 2022-11-20 kl  22 10 19" src="https://user-images.githubusercontent.com/32769446/203014750-49705a5a-646d-4d47-a668-532b9fb40bd5.png">

ETTER:
![Skjermbilde 2022-11-21 kl  10 25 53](https://user-images.githubusercontent.com/32769446/203014772-e8985baf-53a5-438f-a75f-c1bbe6af140f.png)
![Skjermbilde 2022-11-21 kl  10 25 44](https://user-images.githubusercontent.com/32769446/203014773-4644aa3d-ed40-46c5-99c7-ac67a2ca9d47.png)
![Skjermbilde 2022-11-21 kl  10 25 30](https://user-images.githubusercontent.com/32769446/203014777-5e270adb-1989-4f1a-ad87-7f68ff9630f8.png)
