### PR TITLE
Fjernet CPU-limit

### DIFF
--- a/build_n_deploy/naiserator/nais-dev.yaml
+++ b/build_n_deploy/naiserator/nais-dev.yaml
@@ -14,7 +14,6 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   port: 9000
   liveness:
     path: /internal/isAlive
@@ -41,7 +40,6 @@ spec:
         - application: familie-dokument
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/build_n_deploy/naiserator/nais-prod.yaml
+++ b/build_n_deploy/naiserator/nais-prod.yaml
@@ -14,7 +14,6 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   port: 9000
   liveness:
     path: /internal/isAlive
@@ -41,7 +40,6 @@ spec:
         - application: familie-dokument
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)